### PR TITLE
prohibit deletion other's tweet

### DIFF
--- a/app/Http/Controllers/TweetController.php
+++ b/app/Http/Controllers/TweetController.php
@@ -32,6 +32,7 @@ class TweetController extends Controller
         
         $tweet = TweetService::delete_tweet([
             'id' => $request->id, 
+            'user_id' => Auth::id(),
         ]);
 
         // FIX ME

--- a/app/Http/Services/TweetService.php
+++ b/app/Http/Services/TweetService.php
@@ -16,7 +16,7 @@ class TweetService{
 
     public static function delete_tweet($request){
         $tweet = Tweet::find($request['id']);
-        if($tweet){
+        if($tweet && $tweet->user_id==$request['user_id']){
             $tweet->delete();
         }
 

--- a/tests/Unit/TweetTest.php
+++ b/tests/Unit/TweetTest.php
@@ -15,13 +15,14 @@ class TweetTest extends TestCase
      */
     public function test_saving_tweet()
     {
-        //テスト用データの用意
+        // テスト用データの用意
         $tweet = Tweet::factory()->make();
         $tweet_text = $tweet->tweet_text;
         $user_id = $tweet->user_id;
 
 
-        //ツイートが保存されたか(DBのレコードが増えたか)
+        // ツイートが保存されたか(DBのレコードが増えたか)
+        // 期待すること: DBのレコードが1増えている
         $record_num_before = Tweet::count();
 
         $created_tweet = TweetService::create_tweet([
@@ -32,7 +33,8 @@ class TweetTest extends TestCase
         $record_num_after = Tweet::count();
         $this->assertSame($record_num_before + 1, $record_num_after);
 
-        //正しいデータが保存されたか
+        // 正しいデータが保存されたか
+        // 期待すること: 作られたツイートのデータとDBに保存されたデータが一致する
         $saved_tweet = Tweet::find( $created_tweet->id );
         $this->assertSame($saved_tweet->tweet_text, $tweet_text);
         $this->assertSame($saved_tweet->user_id, $user_id);
@@ -46,26 +48,45 @@ class TweetTest extends TestCase
      */
     public function test_deleting_tweet()
     {
-        //テスト用データの用意
-        $tweet = Tweet::factory()->make();
-        $id = 1;
 
-        //ツイートが削除されたか(DBのレコードが減ったか)
+        // テスト用データの用意
+        $tweet = Tweet::factory()->create();
+        $id = $tweet->id;
+        $user_id = $tweet->user_id;
+
+        // (他人が削除しようとしたら)
+        // ツイートが削除されたか
+        // 期待すること: レコードの数が減っていない
         $record_num_before = Tweet::count();
 
         $deleted_tweet = TweetService::delete_tweet([
             'id' => $id,
+            'user_id' => $user_id+1,
+        ]);
+
+        $record_num_after = Tweet::count();
+        $this->assertSame($record_num_before, $record_num_after);
+
+        // (本人が削除しようとしたら)
+        // ツイートが削除されたか
+        // 期待すること: レコードの数が1減っている
+        $record_num_before = Tweet::count();
+
+        $deleted_tweet = TweetService::delete_tweet([
+            'id' => $id,
+            'user_id' => $user_id,
         ]);
 
         $record_num_after = Tweet::count();
         $this->assertSame($record_num_before - 1, $record_num_after);
 
-        //正しいデータが削除されたか
+        // 正しいデータが削除されたか
+        // 期待すること: 削除したツイートのIDが, DBに存在しない
         $this->assertSame(Tweet::find( $deleted_tweet->id ), null);
 
 
 
-        //指定したIDが存在しなかったときに, エラーを吐かずに動作するか
+        // 指定したIDが存在しなかったときに, エラーを吐かずに動作するか
         $deleted_tweet = TweetService::delete_tweet([
             'id' => $id,
         ]);


### PR DESCRIPTION
## 概要
自分のツイート以外は削除できないように修正

### ID=13のユーザが
<img width="1552" alt="user13_tweeted" src="https://user-images.githubusercontent.com/33211163/132786145-626f0e84-fb3e-4de1-82b1-4f0af481f01b.png">

### 自分の投稿したツイートを削除
<img width="1555" alt="delete_tweet31" src="https://user-images.githubusercontent.com/33211163/132786155-ba517f4b-8204-4fdc-b40b-13f5ad85cfab.png">

### できる
<img width="1552" alt="deleted_tweet31" src="https://user-images.githubusercontent.com/33211163/132786169-ad4d8f16-a5bb-4f93-947f-8eb927f2ec7b.png">

### ツイート3もユーザ13のツイートなので
<img width="1555" alt="delete_tweet3" src="https://user-images.githubusercontent.com/33211163/132786174-cffbb304-7be6-4599-ae7b-ebc372051681.png">

### 削除できる
<img width="1552" alt="deleted_tweet3" src="https://user-images.githubusercontent.com/33211163/132786179-4735bd96-39a2-415e-a76b-038e838ae42e.png">

### ツイート1は, ユーザ11のツイートなので
<img width="1555" alt="delete_tweet1" src="https://user-images.githubusercontent.com/33211163/132786184-8f54555b-9732-4d50-ab16-2deb0706e916.png">

### 削除できない
<img width="1552" alt="not_deleted_tweet1" src="https://user-images.githubusercontent.com/33211163/132786186-650c98a3-4072-465c-9a7c-7a4492723872.png">
