### PR TITLE
arrange factory and create home

### DIFF
--- a/app/Http/Controllers/TweetController.php
+++ b/app/Http/Controllers/TweetController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Tweet;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use App\Http\Services\TweetService;
 
@@ -14,7 +15,6 @@ class TweetController extends Controller
 
     //ツイートを作成し, Homeにリダイレクトさせる
     public function add(Request $request){
-
         $tweet = TweetService::create_tweet([
             'tweet_text' => $request->tweet_text, 
             'user_id' => Auth::id(),
@@ -35,9 +35,21 @@ class TweetController extends Controller
         return redirect('/home'); 
     }
 
-    //ツイートを削除し, Homeにリダイレクトさせる
+    //ホームでフォロイーのツイートを表示する
     public function index($page = '1'){
 
-        return view('home', ['page' => $page, 'path' => 'home']); 
+        $tweets = TweetService::get_tweets_at_page([
+            'user_id' => Auth::id(),
+            'page' => $page,
+        ]);
+
+        return view('home', ['page' => $page, 'path' => 'home', 'tweets'=>$tweets]); 
     }
+
+    public function mypage(){
+
+        $me = User::find(Auth::id());
+        return view('mypage', ['me' => $me, 'path' => 'mypage']);
+    }
+
 }

--- a/app/Http/Services/TweetService.php
+++ b/app/Http/Services/TweetService.php
@@ -3,8 +3,15 @@
 namespace App\Http\Services;
 
 use App\Models\Tweet;
+use Illuminate\Support\Facades\DB;
+
 
 class TweetService{
+    
+    // 引数
+    //      tweet_textとuser_idをもつ連想配列
+    // 動作
+    //      user_idのツイートとしてtweet_textをDBに保存する
     public static function create_tweet($request){
         $tweet = Tweet::create([
             'tweet_text' => $request['tweet_text'],
@@ -14,6 +21,10 @@ class TweetService{
         return $tweet;
     }
 
+    // 引数
+    //      id(tweet_id)とuser_idをもつ連想配列
+    // 動作
+    //      ツイートがuser_idのものなら, DBから削除する
     public static function delete_tweet($request){
         $tweet = Tweet::find($request['id']);
         if($tweet && $tweet->user_id==$request['user_id']){
@@ -21,5 +32,29 @@ class TweetService{
         }
 
         return $tweet;
+    }
+
+    // 引数
+    //      user_idとpageをもつ連想配列
+    // 動作
+    //      このpageを表示するツイートを新しい順の配列で返す.
+    //      表示するツイート
+    //          - user_idがフォローしているユーザのツイート
+    //          - 自分のツイート
+    public static function get_tweets_at_page($request){
+        $tweets_num_upper_of_page = 10; //1ページの表示ツイート数上限
+        $skip_tweet_cnt = $tweets_num_upper_of_page * ($request['page'] - 1); //offsetする数
+
+        $tweets = DB::table('tweets')
+            ->join('follows', function ($join) use ($request){
+                $join->on('tweets.user_id', '=', 'follows.followed_user_id')
+                    ->where('follows.following_user_id', '=', $request['user_id']);
+            })
+            ->orderBy('id')
+            ->skip($skip_tweet_cnt)
+            ->take($tweets_num_upper_of_page)
+            ->get();
+
+        return $tweets;
     }
 }

--- a/app/Http/Services/TweetService.php
+++ b/app/Http/Services/TweetService.php
@@ -41,20 +41,20 @@ class TweetService{
     //      表示するツイート
     //          - user_idがフォローしているユーザのツイート
     //          - 自分のツイート
-    public static function get_tweets_at_page($request){
-        $tweets_num_upper_of_page = 10; //1ページの表示ツイート数上限
-        $skip_tweet_cnt = $tweets_num_upper_of_page * ($request['page'] - 1); //offsetする数
+    public const GET_MAX_TWEET_NUM = 10; //1ページの表示ツイート数上限
 
-        $tweets = DB::table('tweets')
+    public static function get_tweets_at_page($request){
+        $skip_tweet_cnt = self::GET_MAX_TWEET_NUM * ($request['page'] - 1); //offsetする数
+
+        return $tweets = DB::table('tweets')
             ->join('follows', function ($join) use ($request){
                 $join->on('tweets.user_id', '=', 'follows.followed_user_id')
                     ->where('follows.following_user_id', '=', $request['user_id']);
             })
             ->orderBy('id')
             ->skip($skip_tweet_cnt)
-            ->take($tweets_num_upper_of_page)
+            ->take(self::GET_MAX_TWEET_NUM)
             ->get();
 
-        return $tweets;
     }
 }

--- a/database/factories/FollowFactory.php
+++ b/database/factories/FollowFactory.php
@@ -16,15 +16,41 @@ class FollowFactory extends Factory
     protected $model = Follow::class;
 
     /**
+     * The user index for follow's factory
+     *
+     * @var integer
+     */
+    public static $user_id1 = 1;
+
+    /**
+     * The user index for follow's factory
+     *
+     * @var integer
+     */
+    public static $user_id2 = 0;
+
+    /**
      * Define the model's default state.
+     * For a user whose id is odd number, this factory make it follow another user whose id is even number.
+     * For a user whose id is even number, this factory make it follow another user whose id is odd number.
      *
      * @return array
      */
     public function definition()
-    {
+    {   
+        self::$user_id2+=2;
+        if(self::$user_id2 > User::count()){
+            self::$user_id1++;
+            self::$user_id2 = self::$user_id1&1 ? 2 : 1; // If user_id1 is odd, set user_id2 2. Else set user_id2 1.
+            
+            // If there is a shortage of users, add User.
+            if(self::$user_id1 > User::count()){
+                User::factory()->create();
+            }
+        }
         return [
-            'following_user_id' => User::factory(),
-            'followed_user_id' => User::factory(),
+            'following_user_id' => self::$user_id1,
+            'followed_user_id' => self::$user_id2,
         ];
     }
 }

--- a/database/factories/TweetFactory.php
+++ b/database/factories/TweetFactory.php
@@ -31,6 +31,9 @@ class TweetFactory extends Factory
     {   
         self::$user_id++;
         if(self::$user_id > User::count()){
+            if(User::count() == 0){
+                User::factory()->create();
+            }
             self::$user_id = 1;
         }
         return [

--- a/database/factories/TweetFactory.php
+++ b/database/factories/TweetFactory.php
@@ -16,15 +16,26 @@ class TweetFactory extends Factory
     protected $model = Tweet::class;
     
     /**
+     * The user index for Tweet's factory
+     *
+     * @var integer
+     */
+    public static $user_id = 0;
+
+    /**
      * Define the model's default state.
      *
      * @return array
      */
     public function definition()
-    {
+    {   
+        self::$user_id++;
+        if(self::$user_id > User::count()){
+            self::$user_id = 1;
+        }
         return [
             'tweet_text' => $this->faker->sentence,
-            'user_id' => User::factory(),
+            'user_id' => self::$user_id,
         ];
     }
 }

--- a/database/factories/TweetFactory.php
+++ b/database/factories/TweetFactory.php
@@ -32,9 +32,10 @@ class TweetFactory extends Factory
         self::$user_id++;
         if(self::$user_id > User::count()){
             if(User::count() == 0){
-                User::factory()->create();
+                self::$user_id = User::factory()->create()->id;
+            }else{
+                self::$user_id = 1;
             }
-            self::$user_id = 1;
         }
         return [
             'tweet_text' => $this->faker->sentence,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,9 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(FollowsTableSeeder::class);
         $this->call(TweetsTableSeeder::class);
         $this->call(LikesTableSeeder::class);
-        $this->call(FollowsTableSeeder::class);
         $this->call(RepliesTableSeeder::class);
     }
 }

--- a/database/seeders/FollowsTableSeeder.php
+++ b/database/seeders/FollowsTableSeeder.php
@@ -14,6 +14,6 @@ class FollowsTableSeeder extends Seeder
      */
     public function run()
     {
-        Follow::factory()->count(10)->create();
+        Follow::factory()->count(100)->create();
     }
 }

--- a/database/seeders/TweetsTableSeeder.php
+++ b/database/seeders/TweetsTableSeeder.php
@@ -14,6 +14,6 @@ class TweetsTableSeeder extends Seeder
      */
     public function run()
     {
-        Tweet::factory()->count(10)->create();
+        Tweet::factory()->count(100)->create();
     }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -30,3 +30,19 @@ footer{
 .float-left{
     float:left;
 }
+
+.tweet-table{
+
+}
+.tweet-cell{
+    border: solid black 1px;
+}
+.tweeter{
+    cursor: pointer;
+}
+.tweet-text{
+    
+}
+.tweet-date{
+    
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,5 +7,20 @@
 
 ツイートを表示({{ $page }}ページ目)
 
+<div class="tweet-table">
+    @forelse ($tweets as $tweet)
+        <div class="tweet-cell">
+            <a href="/user/{{ $tweet->user_id }}" class="tweeter">{{ $tweet->user_id }}</a>
+            <div class="tweet-text">{{ $tweet->tweet_text }}</div>
+            <div class="tweet-date">{{ $tweet->created_at }}</div>
+        </div>
+    @empty
+        <p> フォロイーのツイートがありません. <a href="/user-list">こちら</a>でフォローしましょう！ </p>
+    @endforelse
+</div class="tweet-table">
+
+
+
+
 @endsection
 

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -5,7 +5,7 @@
 
 @section('content')
 
-Mypage
-
+Mypage <br>
+id: {{ $me }}
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,23 +23,23 @@ Route::middleware('auth')->group(function () {
         return view('tweet_form', ['path' => 'tweet-form']);
     });
 
-    Route::post('/tweet-form', [TweetController::class, "add"]);
+    Route::post('/tweet-form', [TweetController::class, 'add']);
 
     Route::get('/delete-form', function () {
         return view('delete_form');
     });
 
-    Route::delete('/delete-form', [TweetController::class, "delete"]);
+    Route::delete('/delete-form', [TweetController::class, 'delete']);
     
-    Route::get('/dashboard', function () {
-        return redirect('/home/1');
-    });
+    // ログアウトのトリガーを実装したらこっちを採用
+    // Route::get('/dashboard', function () {
+    //     return view('dashboard')->name('dashboard');
+    //     // return redirect('/home/1');
+    // });
 
-    Route::get('/home/{page?}', [TweetController::class, "index"] );
+    Route::get('/home/{page?}', [TweetController::class, 'index'] );
 
-    Route::get('/mypage', function () {
-        return view('mypage', ['path' => 'mypage']);
-    });
+    Route::get('/mypage', [TweetController::class, 'mypage']);
     
     Route::get('/user-list', function () {
         return view('user_list', ['path' => 'user-list']);
@@ -47,7 +47,10 @@ Route::middleware('auth')->group(function () {
 
 });
 
-
+// ログアウトのトリガーを実装するまで残す
+Route::get('/dashboard', function () {
+    return view('dashboard');
+})->middleware(['auth'])->name('dashboard');
 
 
 require __DIR__.'/auth.php';

--- a/tests/Unit/TweetTest.php
+++ b/tests/Unit/TweetTest.php
@@ -97,6 +97,7 @@ class TweetTest extends TestCase
 
     }   
 
+    public const GET_MAX_TWEET_NUM = 10; //1ページの表示ツイート数上限
 
     /**
      * A unit test for listing tweets.
@@ -113,8 +114,7 @@ class TweetTest extends TestCase
         $followed_user_list = Follow::where('following_user_id', $user_id) -> get();
 
         $page = 2;
-        $tweets_num_upper_of_page = 10; //1ページの表示ツイート数上限
-        $skip_tweet_cnt = $tweets_num_upper_of_page * ($page - 1); //offsetする数
+        $skip_tweet_cnt = self::GET_MAX_TWEET_NUM * ($page - 1); //offsetする数
 
         $tweets = DB::table('tweets')
             ->join('follows', function ($join) use ($user_id){

--- a/tests/Unit/TweetTest.php
+++ b/tests/Unit/TweetTest.php
@@ -4,10 +4,14 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use App\Models\Tweet;
+use App\Models\User;
+use App\Models\Follow;
 use App\Http\Services\TweetService;
+use Illuminate\Support\Facades\DB;
 
 class TweetTest extends TestCase
 {
+    // use RefreshDatabase;
     /**
      * A unit test for saving tweet.
      *
@@ -24,7 +28,7 @@ class TweetTest extends TestCase
         // ツイートが保存されたか(DBのレコードが増えたか)
         // 期待すること: DBのレコードが1増えている
         $record_num_before = Tweet::count();
-
+        
         $created_tweet = TweetService::create_tweet([
             'tweet_text' => $tweet_text,
             'user_id' => $user_id,
@@ -53,7 +57,7 @@ class TweetTest extends TestCase
         $tweet = Tweet::factory()->create();
         $id = $tweet->id;
         $user_id = $tweet->user_id;
-
+        
         // (他人が削除しようとしたら)
         // ツイートが削除されたか
         // 期待すること: レコードの数が減っていない
@@ -92,4 +96,43 @@ class TweetTest extends TestCase
         ]);
 
     }   
+
+
+    /**
+     * A unit test for listing tweets.
+     *
+     * @return void
+     */
+    public function test_listing_tweets()
+    {
+        $user = User::factory()->create();
+        $user_id = $user->id;
+
+        Follow::factory()->count(30)->create();
+        Tweet::factory()->count(1000)->create();
+        $followed_user_list = Follow::where('following_user_id', $user_id) -> get();
+
+        $page = 2;
+        $tweets_num_upper_of_page = 10; //1ページの表示ツイート数上限
+        $skip_tweet_cnt = $tweets_num_upper_of_page * ($page - 1); //offsetする数
+
+        $tweets = DB::table('tweets')
+            ->join('follows', function ($join) use ($user_id){
+                $join->on('tweets.user_id', '=', 'follows.followed_user_id')
+                    ->where('follows.following_user_id', '=', $user_id);
+            })
+            ->orderBy('id')
+            ->get();
+
+
+        $listed_tweet = TweetService::get_tweets_at_page([
+            'user_id' => $user_id,
+            'page' => $page,
+        ]);
+
+        for($idx=0; $idx<min(10, count($tweets) - $skip_tweet_cnt); $idx++){
+            $this->assertSame($tweets[$idx + $skip_tweet_cnt]->id, $listed_tweet[$idx]->id);
+        }
+    }
+    
 }

--- a/tests/Unit/TweetTest.php
+++ b/tests/Unit/TweetTest.php
@@ -28,7 +28,7 @@ class TweetTest extends TestCase
         // ツイートが保存されたか(DBのレコードが増えたか)
         // 期待すること: DBのレコードが1増えている
         $record_num_before = Tweet::count();
-        
+
         $created_tweet = TweetService::create_tweet([
             'tweet_text' => $tweet_text,
             'user_id' => $user_id,
@@ -57,7 +57,7 @@ class TweetTest extends TestCase
         $tweet = Tweet::factory()->create();
         $id = $tweet->id;
         $user_id = $tweet->user_id;
-        
+
         // (他人が削除しようとしたら)
         // ツイートが削除されたか
         // 期待すること: レコードの数が減っていない


### PR DESCRIPTION
## 概要
- seeder, factoryの変更
  - 既存のユーザがツイートやフォローをしたようなデータを作成するように修正
- ホーム画面の作成
- ページ分け(1ページ10ツイートまで)
  - テストの作成

### DBにあるのツイート
<img width="1552" alt="tweets_on_DB" src="https://user-images.githubusercontent.com/33211163/132824305-b5c3063c-334e-432a-b079-4ba43dfaa572.png">

### フォロー関係
<img width="1552" alt="follows_on_DB" src="https://user-images.githubusercontent.com/33211163/132824390-cf1d7ddd-65c4-40a3-806a-9a5c9b9920db.png">

### 画面で確認
<img width="1555" alt="画面での確認" src="https://user-images.githubusercontent.com/33211163/132824606-e9d01697-37da-4cb8-84e9-71ee26711718.png">

## まだやっていないこと
- 画面の整形
- ユーザIDではなくユーザ名を表示したい
